### PR TITLE
Remove addons- prefix from repo names

### DIFF
--- a/src/MilestoneIssues.js
+++ b/src/MilestoneIssues.js
@@ -149,7 +149,11 @@ class MilestoneIssues extends Component {
           }
         });
 
-        const repoName = issue.repository_url.split('/').slice(-1).join('/');
+        const repoName = issue.repository_url
+          .split('/')
+          .slice(-1)
+          .join('/')
+          .replace('addons-', '');
         /* eslint-disable jsx-a11y/href-no-hash */
         return (
           <Tr key={idx}>


### PR DESCRIPTION
I did not want to tinker with the CSS, so I simply stripped the `addons-` prefix from the repo names:

<img width="1392" alt="screen shot 2019-01-23 at 11 37 40" src="https://user-images.githubusercontent.com/217628/51600905-513fa800-1f03-11e9-8f58-f19a4e3b3640.png">
